### PR TITLE
Add paper management pages

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Navbar from "@/components/navbar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,6 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <Navbar />
         {children}
       </body>
     </html>

--- a/app/papers/[id]/page.tsx
+++ b/app/papers/[id]/page.tsx
@@ -1,0 +1,18 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function PaperDetailPage({ params }: { params: { id: string } }) {
+  const { id } = params;
+  return (
+    <main className="p-4 flex justify-center">
+      <Card className="w-full max-w-xl">
+        <CardHeader>
+          <CardTitle>Paper Detail</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <p>ID: {id}</p>
+          {/* Additional paper details would go here */}
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/app/papers/[id]/page.tsx
+++ b/app/papers/[id]/page.tsx
@@ -1,18 +1,24 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { getPaper } from "@/lib/demo-data"
+import { notFound } from "next/navigation"
 
 export default function PaperDetailPage({ params }: { params: { id: string } }) {
-  const { id } = params;
+  const { id } = params
+  const paper = getPaper(id)
+  if (!paper) {
+    return notFound()
+  }
   return (
     <main className="p-4 flex justify-center">
       <Card className="w-full max-w-xl">
         <CardHeader>
-          <CardTitle>Paper Detail</CardTitle>
+          <CardTitle>{paper.title}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-2">
-          <p>ID: {id}</p>
-          {/* Additional paper details would go here */}
+          <p className="text-sm text-muted-foreground">{paper.authors}</p>
+          <p>{paper.abstract}</p>
         </CardContent>
       </Card>
     </main>
-  );
+  )
 }

--- a/app/papers/add/page.tsx
+++ b/app/papers/add/page.tsx
@@ -15,6 +15,9 @@ export default function AddPaperPage() {
             <Input placeholder="Authors" required />
             <Button type="submit">Save</Button>
           </form>
+          <p className="text-sm text-muted-foreground">
+            This demo form does not actually save data.
+          </p>
         </CardContent>
       </Card>
     </main>

--- a/app/papers/add/page.tsx
+++ b/app/papers/add/page.tsx
@@ -1,0 +1,22 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+export default function AddPaperPage() {
+  return (
+    <main className="p-4 flex justify-center">
+      <Card className="w-full max-w-xl">
+        <CardHeader>
+          <CardTitle>Add Paper</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <form className="space-y-4">
+            <Input placeholder="Title" required />
+            <Input placeholder="Authors" required />
+            <Button type="submit">Save</Button>
+          </form>
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/app/papers/add/page.tsx
+++ b/app/papers/add/page.tsx
@@ -10,9 +10,9 @@ export default function AddPaperPage() {
           <CardTitle>Add Paper</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <form className="space-y-4">
-            <Input placeholder="Title" required />
-            <Input placeholder="Authors" required />
+          <form className="space-y-4" encType="multipart/form-data">
+            <Input placeholder="DOI" name="doi" required />
+            <Input type="file" accept="application/pdf" name="pdf" required />
             <Button type="submit">Save</Button>
           </form>
           <p className="text-sm text-muted-foreground">

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,12 +1,27 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { notFound } from "next/navigation";
+import Link from "next/link"
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { searchPapers } from "@/lib/demo-data"
+import { notFound } from "next/navigation"
 
 export default function SearchPage({ searchParams }: { searchParams?: { q?: string } }) {
   const query = searchParams?.q || "";
   if (!query) {
     return notFound();
   }
+  const results = searchPapers(query)
 
   return (
     <main className="p-4">
@@ -23,11 +38,20 @@ export default function SearchPage({ searchParams }: { searchParams?: { q?: stri
               </TableRow>
             </TableHeader>
             <TableBody>
-              {/* Placeholder for search results */}
-              <TableRow>
-                <TableCell>Example Paper</TableCell>
-                <TableCell>John Doe</TableCell>
-              </TableRow>
+              {results.length ? (
+                results.map((paper) => (
+                  <TableRow key={paper.id}>
+                    <TableCell>
+                      <Link href={`/papers/${paper.id}`}>{paper.title}</Link>
+                    </TableCell>
+                    <TableCell>{paper.authors}</TableCell>
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={2}>No results found.</TableCell>
+                </TableRow>
+              )}
             </TableBody>
           </Table>
         </CardContent>

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,37 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { notFound } from "next/navigation";
+
+export default function SearchPage({ searchParams }: { searchParams?: { q?: string } }) {
+  const query = searchParams?.q || "";
+  if (!query) {
+    return notFound();
+  }
+
+  return (
+    <main className="p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>{`Search results for "${query}"`}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Title</TableHead>
+                <TableHead>Authors</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {/* Placeholder for search results */}
+              <TableRow>
+                <TableCell>Example Paper</TableCell>
+                <TableCell>John Doe</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+
+export default function Navbar() {
+  return (
+    <nav className="border-b p-4 flex gap-4 items-center justify-between">
+      <Link href="/" className="font-semibold">Paper Manager</Link>
+      <form action="/search" className="flex-1 max-w-md ml-auto">
+        <Input name="q" placeholder="Search papers" />
+      </form>
+      <Button asChild>
+        <Link href="/papers/add">Add Paper</Link>
+      </Button>
+    </nav>
+  )
+}

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -1,0 +1,39 @@
+export type Paper = {
+  id: string
+  title: string
+  authors: string
+  abstract: string
+}
+
+export const papers: Paper[] = [
+  {
+    id: '1',
+    title: 'A Study on React Components',
+    authors: 'Jane Doe, John Smith',
+    abstract: 'An exploration of React component patterns and best practices.'
+  },
+  {
+    id: '2',
+    title: 'Next.js for Beginners',
+    authors: 'Alice Example',
+    abstract: 'Introduction to building web applications using Next.js.'
+  },
+  {
+    id: '3',
+    title: 'Advances in TypeScript',
+    authors: 'Bob Developer',
+    abstract: 'Recent features and improvements in the TypeScript language.'
+  },
+]
+
+export function searchPapers(query: string): Paper[] {
+  const q = query.toLowerCase()
+  return papers.filter(
+    (p) =>
+      p.title.toLowerCase().includes(q) || p.authors.toLowerCase().includes(q)
+  )
+}
+
+export function getPaper(id: string): Paper | undefined {
+  return papers.find((p) => p.id === id)
+}


### PR DESCRIPTION
## Summary
- add Navbar component with search and add button
- include Navbar in layout
- add page to add a paper
- add search results page
- add paper detail page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68468b29964c832992466710a41ae6eb