### PR TITLE
Add paper upload API

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,6 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## GitHub Upload Configuration
+Set the `GITHUB_OWNER`, `GITHUB_REPO` and `GITHUB_TOKEN` environment variables to enable the paper upload API.

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ The easiest way to deploy your Next.js app is to use the [Vercel Platform](https
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
 
 ## GitHub Upload Configuration
-Set the `GITHUB_OWNER`, `GITHUB_REPO` and `GITHUB_TOKEN` environment variables to enable the paper upload API.
+Set the `GITHUB_OWNER`, `GITHUB_REPO` and `GITHUB_TOKEN` environment variables to enable the paper upload API. Uploaded PDFs are placed in the `papers` directory of your repository.

--- a/app/api/papers/add/route.ts
+++ b/app/api/papers/add/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createHash } from 'crypto'
+
+export async function POST(req: NextRequest) {
+  const formData = await req.formData()
+  const doi = formData.get('doi')
+  const file = formData.get('pdf')
+
+  if (!doi || typeof doi !== 'string' || !(file instanceof Blob)) {
+    return NextResponse.json({ error: 'Invalid input' }, { status: 400 })
+  }
+
+  const owner = process.env.GITHUB_OWNER
+  const repo = process.env.GITHUB_REPO
+  const token = process.env.GITHUB_TOKEN
+
+  if (!owner || !repo || !token) {
+    return NextResponse.json({ error: 'Server not configured' }, { status: 500 })
+  }
+
+  const hash = createHash('sha256').update(doi).digest('hex')
+  const branch = `add-paper-${hash}`
+  const path = `${hash}.pdf`
+
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    'User-Agent': 'giants-app',
+    Accept: 'application/vnd.github+json'
+  }
+
+  const repoRes = await fetch(`https://api.github.com/repos/${owner}/${repo}`, { headers })
+  if (!repoRes.ok) {
+    const text = await repoRes.text()
+    return NextResponse.json({ error: 'Failed to get repo', details: text }, { status: 500 })
+  }
+  const repoData = await repoRes.json()
+  const defaultBranch = repoData.default_branch
+
+  const refRes = await fetch(`https://api.github.com/repos/${owner}/${repo}/git/ref/heads/${defaultBranch}`, { headers })
+  if (!refRes.ok) {
+    const text = await refRes.text()
+    return NextResponse.json({ error: 'Failed to get branch ref', details: text }, { status: 500 })
+  }
+  const refData = await refRes.json()
+  const baseSha = refData.object.sha
+
+  const createBranchRes = await fetch(`https://api.github.com/repos/${owner}/${repo}/git/refs`, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ref: `refs/heads/${branch}`, sha: baseSha })
+  })
+  if (!createBranchRes.ok) {
+    const text = await createBranchRes.text()
+    return NextResponse.json({ error: 'Failed to create branch', details: text }, { status: 500 })
+  }
+
+  const buffer = Buffer.from(await (file as Blob).arrayBuffer())
+  const content = buffer.toString('base64')
+
+  const createFileRes = await fetch(`https://api.github.com/repos/${owner}/${repo}/contents/${path}`, {
+    method: 'PUT',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message: `Add paper ${doi}`, content, branch })
+  })
+  if (!createFileRes.ok) {
+    const text = await createFileRes.text()
+    return NextResponse.json({ error: 'Failed to create file', details: text }, { status: 500 })
+  }
+
+  const prRes = await fetch(`https://api.github.com/repos/${owner}/${repo}/pulls`, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      title: `Add paper ${doi}`,
+      head: branch,
+      base: defaultBranch,
+      body: 'Automated paper upload'
+    })
+  })
+  if (!prRes.ok) {
+    const text = await prRes.text()
+    return NextResponse.json({ error: 'Failed to create pull request', details: text }, { status: 500 })
+  }
+  const prData = await prRes.json()
+
+  return NextResponse.json({ url: prData.html_url })
+}

--- a/app/api/papers/add/route.ts
+++ b/app/api/papers/add/route.ts
@@ -20,7 +20,7 @@ export async function POST(req: NextRequest) {
 
   const hash = createHash('sha256').update(doi).digest('hex')
   const branch = `add-paper-${hash}`
-  const path = `${hash}.pdf`
+  const path = `papers/${hash}.pdf`
 
   const headers = {
     Authorization: `Bearer ${token}`,

--- a/app/papers/add/page.tsx
+++ b/app/papers/add/page.tsx
@@ -21,7 +21,8 @@ export default function AddPaperPage() {
             <Button type="submit">Save</Button>
           </form>
           <p className="text-sm text-muted-foreground">
-            Submitting the form creates a pull request with the uploaded PDF.
+            Submitting the form creates a pull request with the uploaded PDF in the
+            <code>papers</code> directory.
           </p>
         </CardContent>
       </Card>

--- a/app/papers/add/page.tsx
+++ b/app/papers/add/page.tsx
@@ -10,13 +10,18 @@ export default function AddPaperPage() {
           <CardTitle>Add Paper</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <form className="space-y-4" encType="multipart/form-data">
+          <form
+            className="space-y-4"
+            action="/api/papers/add"
+            method="post"
+            encType="multipart/form-data"
+          >
             <Input placeholder="DOI" name="doi" required />
             <Input type="file" accept="application/pdf" name="pdf" required />
             <Button type="submit">Save</Button>
           </form>
           <p className="text-sm text-muted-foreground">
-            This demo form does not actually save data.
+            Submitting the form creates a pull request with the uploaded PDF.
           </p>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- add route handler that creates a pull request with the uploaded PDF
- wire papers/add form to call the new API
- document GitHub configuration for uploads

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68468f96d1988329a107e9d2f48ee47f