### PR TITLE
Use paper JSON data on details page

### DIFF
--- a/app/papers/[id]/page.tsx
+++ b/app/papers/[id]/page.tsx
@@ -1,13 +1,18 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { getPaper } from "@/lib/demo-data"
-import { notFound } from "next/navigation"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { getPaper, listPaperIds } from "@/lib/papers";
+import { notFound } from "next/navigation";
 
-export default function PaperDetailPage({ params }: { params: { id: string } }) {
-  const { id } = params
-  const paper = getPaper(id)
+export default async function PaperDetailPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const { id } = params;
+  const paper = await getPaper(id);
   if (!paper) {
-    return notFound()
+    return notFound();
   }
+  const authors = paper.authors.map((a) => a.name).join(", ");
   return (
     <main className="p-4 flex justify-center">
       <Card className="w-full max-w-xl">
@@ -15,10 +20,15 @@ export default function PaperDetailPage({ params }: { params: { id: string } }) 
           <CardTitle>{paper.title}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-2">
-          <p className="text-sm text-muted-foreground">{paper.authors}</p>
-          <p>{paper.abstract}</p>
+          <p className="text-sm text-muted-foreground">{authors}</p>
+          <p>{paper.abstract || "No abstract available."}</p>
         </CardContent>
       </Card>
     </main>
-  )
+  );
+}
+
+export async function generateStaticParams() {
+  const ids = await listPaperIds();
+  return ids.map((id) => ({ id }));
 }

--- a/lib/papers.ts
+++ b/lib/papers.ts
@@ -1,0 +1,35 @@
+import fs from "fs/promises";
+import path from "path";
+
+export type Author = {
+  authorId: string;
+  name: string;
+};
+
+export type Paper = {
+  paperId: string;
+  title: string;
+  year?: number;
+  abstract: string | null;
+  authors: Author[];
+  openAccessPdf?: { url: string };
+};
+
+const papersDir = path.join(process.cwd(), "papers");
+
+export async function listPaperIds(): Promise<string[]> {
+  const files = await fs.readdir(papersDir);
+  return files
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => f.replace(/\.json$/, ""));
+}
+
+export async function getPaper(id: string): Promise<Paper | null> {
+  try {
+    const filePath = path.join(process.cwd(), "papers", `${id}.json`);
+    const data = await fs.readFile(filePath, "utf8");
+    return JSON.parse(data) as Paper;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add library for loading paper JSON files
- update paper details page to read data from the `papers` folder
- statically generate paper pages with `generateStaticParams`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6847c83d3ae88329b93f8c95624d6533