### PR TITLE
Add metadata JSON upload with Semantic Scholar API

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ The easiest way to deploy your Next.js app is to use the [Vercel Platform](https
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
 
 ## GitHub Upload Configuration
-Set the `GITHUB_OWNER`, `GITHUB_REPO` and `GITHUB_TOKEN` environment variables to enable the paper upload API. Uploaded PDFs are placed in the `papers` directory of your repository.
+Set the `GITHUB_OWNER`, `GITHUB_REPO` and `GITHUB_TOKEN` environment variables to enable the paper upload API. Uploaded PDFs and metadata JSON files are placed in the `papers` directory of your repository.


### PR DESCRIPTION
## Summary
- upload Semantic Scholar metadata alongside PDF when adding papers
- document that metadata JSON files are stored in the `papers` directory

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6847db46860c8329bf982235249265e4