### PR TITLE
Move Semantic Scholar call to client

### DIFF
--- a/app/api/papers/add/route.ts
+++ b/app/api/papers/add/route.ts
@@ -5,9 +5,16 @@ import { Octokit } from "@octokit/rest";
 export async function POST(req: NextRequest) {
   const formData = await req.formData();
   const doi = formData.get("doi");
+  const metadata = formData.get("metadata");
   const file = formData.get("pdf");
 
-  if (!doi || typeof doi !== "string" || !(file instanceof Blob)) {
+  if (
+    !doi ||
+    typeof doi !== "string" ||
+    !metadata ||
+    typeof metadata !== "string" ||
+    !(file instanceof Blob)
+  ) {
     return NextResponse.json({ error: "Invalid input" }, { status: 400 });
   }
 
@@ -75,18 +82,7 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const fields = "paperId,title,abstract,year,authors.name";
-  const metaRes = await fetch(
-    `https://api.semanticscholar.org/graph/v1/paper/DOI:${encodeURIComponent(doi)}?fields=${fields}`,
-  );
-  if (!metaRes.ok) {
-    const text = await metaRes.text();
-    return NextResponse.json(
-      { error: "Failed to fetch metadata", details: text },
-      { status: 500 },
-    );
-  }
-  const paperData = await metaRes.json();
+  const paperData = JSON.parse(metadata);
   const jsonContent = Buffer.from(JSON.stringify(paperData, null, 2)).toString(
     "base64",
   );

--- a/app/papers/add/page.tsx
+++ b/app/papers/add/page.tsx
@@ -1,8 +1,53 @@
+"use client";
+
+import { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 
 export default function AddPaperPage() {
+  const [doi, setDoi] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!file) return;
+    const fields = "paperId,title,abstract,year,authors.name";
+    let metadata: unknown;
+    try {
+      const res = await fetch(
+        `https://api.semanticscholar.org/graph/v1/paper/DOI:${encodeURIComponent(
+          doi,
+        )}?fields=${fields}`,
+      );
+      if (!res.ok) {
+        throw new Error(await res.text());
+      }
+      metadata = await res.json();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to fetch metadata");
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append("doi", doi);
+    formData.append("metadata", JSON.stringify(metadata));
+    formData.append("pdf", file);
+
+    const upload = await fetch("/api/papers/add", {
+      method: "POST",
+      body: formData,
+    });
+
+    if (upload.ok) {
+      const data = (await upload.json()) as { url: string };
+      window.location.href = data.url;
+    } else {
+      const err = await upload.json().catch(() => null);
+      alert(err?.error || "Upload failed");
+    }
+  }
+
   return (
     <main className="p-4 flex justify-center">
       <Card className="w-full max-w-xl">
@@ -10,18 +55,24 @@ export default function AddPaperPage() {
           <CardTitle>Add Paper</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <form
-            className="space-y-4"
-            action="/api/papers/add"
-            method="post"
-            encType="multipart/form-data"
-          >
-            <Input placeholder="DOI" name="doi" required />
-            <Input type="file" accept="application/pdf" name="pdf" required />
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <Input
+              placeholder="DOI"
+              value={doi}
+              onChange={(e) => setDoi(e.target.value)}
+              required
+            />
+            <Input
+              type="file"
+              accept="application/pdf"
+              onChange={(e) => setFile(e.target.files?.[0] || null)}
+              required
+            />
             <Button type="submit">Save</Button>
           </form>
           <p className="text-sm text-muted-foreground">
-            Submitting the form creates a pull request with the uploaded PDF in the
+            Submitting the form creates a pull request with the uploaded PDF in
+            the
             <code>papers</code> directory.
           </p>
         </CardContent>


### PR DESCRIPTION
## Summary
- fetch Semantic Scholar metadata client-side before submitting form
- update API route to accept metadata instead of fetching it

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68481033a1a483298ce4a374e0e8f72e