### PR TITLE
Add marker workflow

### DIFF
--- a/.github/workflows/marker.yml
+++ b/.github/workflows/marker.yml
@@ -1,0 +1,35 @@
+name: Run Marker on changes
+
+on:
+  pull_request:
+    paths:
+      - "lib/**/*.ts"
+    types: [opened, synchronize]
+
+jobs:
+  marker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install marker
+        run: pip install marker
+      - name: Run marker script for changed files
+        run: |
+          changed_files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} -- 'lib/**/*.ts')
+          for file in $changed_files; do
+            ./scripts/run_marker.sh "$file"
+          done
+      - name: Commit marker outputs
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "Add marker outputs"
+            git push
+          fi

--- a/scripts/run_marker.sh
+++ b/scripts/run_marker.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FILE="$1"
+DIR="${FILE%.*}"
+mkdir -p "$DIR"
+marker "$DIR"


### PR DESCRIPTION
## Summary
- add workflow to run datalab-to/marker on changed `lib/*.ts` files
- include shell script to call the marker command

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684817f1ade0832990cf5ed1b318c04a