### PR TITLE
Add cache step for Marker workflow

### DIFF
--- a/.github/workflows/marker.yml
+++ b/.github/workflows/marker.yml
@@ -16,11 +16,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.x"
-      - name: Cache Marker models
-        uses: actions/cache@v3
-        with:
-          path: /home/runner/.cache/datalab/models/
-          key: datalab-models-${{ runner.os }}-v1
       - name: Install marker
         run: pip install marker-pdf
       - name: Run marker script for changed files
@@ -31,6 +26,11 @@ jobs:
             [ -z "$file" ] && continue
             ./scripts/run_marker.sh "$file"
           done
+      - name: Cache Marker models
+        uses: actions/cache@v3
+        with:
+          path: /home/runner/.cache/datalab/models/
+          key: datalab-models-${{ runner.os }}
       - name: Commit marker outputs
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/marker.yml
+++ b/.github/workflows/marker.yml
@@ -16,6 +16,11 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.x"
+      - name: Cache Marker models
+        uses: actions/cache@v3
+        with:
+          path: /home/runner/.cache/datalab/models/
+          key: datalab-models-${{ runner.os }}-v1
       - name: Install marker
         run: pip install marker-pdf
       - name: Run marker script for changed files


### PR DESCRIPTION
## Summary
- speed up Marker by caching model downloads

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68483e70a478832986ea207cbd213c48