### PR TITLE
Allow manual paper metadata entry

### DIFF
--- a/app/papers/add/page.tsx
+++ b/app/papers/add/page.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 
 export default function AddPaperPage() {
@@ -17,6 +18,14 @@ export default function AddPaperPage() {
             encType="multipart/form-data"
           >
             <Input placeholder="DOI" name="doi" required />
+            <Input placeholder="Title" name="title" required />
+            <Input placeholder="Year" name="year" type="number" />
+            <Input
+              placeholder="Authors (comma separated)"
+              name="authors"
+              required
+            />
+            <Textarea placeholder="Abstract" name="abstract" />
             <Input type="file" accept="application/pdf" name="pdf" required />
             <Button type="submit">Save</Button>
           </form>


### PR DESCRIPTION
## Summary
- add form fields for paper details on the Add Paper page
- parse submitted fields in the upload API instead of calling Semantic Scholar

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68496e7b46a8832988e39e9fab813590