### PR TITLE
Add pip cache to marker workflow

### DIFF
--- a/.github/workflows/marker.yml
+++ b/.github/workflows/marker.yml
@@ -16,8 +16,20 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.x"
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('Pipfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install marker
         run: pip install marker-pdf
+      - name: Cache Marker models
+        uses: actions/cache@v3
+        with:
+          path: /home/runner/.cache/datalab/models/
+          key: datalab-models-${{ runner.os }}
       - name: Run marker script for changed files
         shell: bash
         run: |
@@ -26,11 +38,6 @@ jobs:
             [ -z "$file" ] && continue
             ./scripts/run_marker.sh "$file"
           done
-      - name: Cache Marker models
-        uses: actions/cache@v3
-        with:
-          path: /home/runner/.cache/datalab/models/
-          key: datalab-models-${{ runner.os }}
       - name: Commit marker outputs
         run: |
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary
- cache pip packages in `.github/workflows/marker.yml`
- move `Cache Marker models` step before running the marker script

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849708310948329b39b03eee227f138