### PR TITLE
Remove authorId field

### DIFF
--- a/app/api/papers/add/route.ts
+++ b/app/api/papers/add/route.ts
@@ -93,7 +93,7 @@ export async function POST(req: NextRequest) {
     .split(",")
     .map((a) => a.trim())
     .filter(Boolean)
-    .map((name) => ({ authorId: "", name }));
+    .map((name) => ({ name }));
 
   const paperData = {
     paperId: doi,

--- a/lib/papers.ts
+++ b/lib/papers.ts
@@ -2,7 +2,6 @@ import fs from "fs/promises";
 import path from "path";
 
 export type Author = {
-  authorId: string;
   name: string;
 };
 


### PR DESCRIPTION
## Summary
- drop `authorId` from `Author` type
- remove unused `authorId` when processing authors

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68497777fc14832981eb94290b49bd16