### PR TITLE
Add loading and toast on paper upload

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 
 import "./globals.css";
 import { Navbar } from "@/components/navbar";
+import { Toaster } from "@/components/ui/sonner";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,6 +31,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <Navbar />
+        <Toaster />
         {children}
       </body>
     </html>

--- a/components/add-paper-form.tsx
+++ b/components/add-paper-form.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -75,9 +77,10 @@ export function AddPaperForm() {
       });
       if (!res.ok) {
         const json = await res.json();
-        alert(json.error || "Failed to submit");
+        toast.error(json.error || "Failed to submit");
       } else {
         const json = await res.json();
+        toast.success("Pull request created");
         if (json.url) {
           window.location.href = json.url;
         }
@@ -177,7 +180,8 @@ export function AddPaperForm() {
           )}
         />
         <Button type="submit" disabled={submitting}>
-          Save
+          {submitting && <Loader2 className="animate-spin" />}
+          {submitting ? "Submitting..." : "Save"}
         </Button>
       </form>
     </Form>


### PR DESCRIPTION
## Summary
- show loading indicator on Add Paper form submit button
- display Sonner toast messages and set up Toaster globally

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a65dc53948329b229af323ecd77a1