### PR TITLE
Enable async translation with progress bar

### DIFF
--- a/scripts/translate_markdown.py
+++ b/scripts/translate_markdown.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 import sys
 import os
+import asyncio
 
 import openai
 from markdown_it import MarkdownIt
+from tqdm.asyncio import tqdm
 
 
 SYSTEM_PROMPT = (
@@ -11,15 +13,15 @@ SYSTEM_PROMPT = (
     "Only translate the prose and leave any headings, images, formulas, or code unchanged."
 )
 
-def translate_paragraph(client: openai.OpenAI, text: str) -> str:
-    response = client.chat.completions.create(
+async def translate_paragraph(client: openai.AsyncOpenAI, text: str) -> str:
+    response = await client.chat.completions.create(
         model="gpt-4.1",
         messages=[{"role": "system", "content": SYSTEM_PROMPT}, {"role": "user", "content": text}],
     )
     return response.choices[0].message.content.strip()
 
 
-def translate_file(path: str) -> None:
+async def translate_file(path: str) -> None:
     with open(path, "r", encoding="utf-8") as f:
         lines = f.readlines()
 
@@ -28,20 +30,33 @@ def translate_file(path: str) -> None:
     tokens = md.parse(text)
 
     api_key = os.environ["OPENAI_API_KEY"]
-    client = openai.OpenAI(api_key=api_key)
+    client = openai.AsyncOpenAI(api_key=api_key)
 
-    output_lines = []
-    current = 0
+    paragraphs: list[str] = []
+    positions: list[tuple[int, int]] = []
     for token in tokens:
         if token.type == "paragraph_open" and token.map:
             start, end = token.map
-            # copy lines before this paragraph
-            output_lines.extend(lines[current:start])
+            paragraphs.append("".join(lines[start:end]).rstrip("\n"))
+            positions.append((start, end))
 
-            paragraph = "".join(lines[start:end]).rstrip("\n")
-            translated = translate_paragraph(client, paragraph)
-            output_lines.append(translated + "\n")
-            current = end
+    tasks = {
+        asyncio.create_task(translate_paragraph(client, para)): idx
+        for idx, para in enumerate(paragraphs)
+    }
+
+    results: list[str | None] = [None] * len(paragraphs)
+    for task in tqdm(asyncio.as_completed(tasks), total=len(tasks)):
+        res = await task
+        idx = tasks[task]
+        results[idx] = res
+
+    output_lines = []
+    current = 0
+    for idx, (start, end) in enumerate(positions):
+        output_lines.extend(lines[current:start])
+        output_lines.append(results[idx] + "\n")
+        current = end
 
     output_lines.extend(lines[current:])
 
@@ -50,5 +65,8 @@ def translate_file(path: str) -> None:
         f.writelines(output_lines)
 
 if __name__ == "__main__":
-    for arg in sys.argv[1:]:
-        translate_file(arg)
+    async def main() -> None:
+        for arg in sys.argv[1:]:
+            await translate_file(arg)
+
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- improve markdown translation script to use `openai.AsyncOpenAI`
- run multiple translation requests concurrently
- show translation progress via a progress bar

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a82cd36fc8329b42dfc0dfc55f962