### PR TITLE
Widen container widths across pages

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,7 @@ export default async function Home() {
 
   return (
     <main className="container mx-auto p-4 space-y-6">
-      <Card className="max-w-2xl mx-auto">
+      <Card className="max-w-3xl mx-auto">
         <CardHeader>
           <CardTitle>Standing on the Shoulders of Giants</CardTitle>
         </CardHeader>
@@ -35,7 +35,7 @@ export default async function Home() {
         </CardContent>
       </Card>
       {papers.length > 0 && (
-        <Card className="max-w-2xl mx-auto">
+        <Card className="max-w-3xl mx-auto">
           <CardHeader>
             <CardTitle>Available Papers</CardTitle>
           </CardHeader>

--- a/app/papers/[id]/page.tsx
+++ b/app/papers/[id]/page.tsx
@@ -20,7 +20,7 @@ export default async function PaperDetailPage({
   const authors = paper.authors.map((a) => a.name).join(", ");
   return (
     <main className="container mx-auto p-4">
-      <Card className="w-full max-w-2xl mx-auto">
+      <Card className="w-full max-w-3xl mx-auto">
         <CardHeader className="space-y-1">
           <CardTitle>{paper.title}</CardTitle>
           <p className="text-sm text-muted-foreground">

--- a/app/papers/add/page.tsx
+++ b/app/papers/add/page.tsx
@@ -4,7 +4,7 @@ import { AddPaperForm } from "@/components/add-paper-form";
 export default function AddPaperPage() {
   return (
     <main className="container mx-auto p-4">
-      <Card className="w-full max-w-2xl mx-auto">
+      <Card className="w-full max-w-3xl mx-auto">
         <CardHeader>
           <CardTitle>Add Paper</CardTitle>
         </CardHeader>

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -25,7 +25,7 @@ export default async function SearchPage({
 
   return (
     <main className="container mx-auto p-4">
-      <Card className="max-w-2xl mx-auto">
+      <Card className="max-w-3xl mx-auto">
         <CardHeader>
           <CardTitle>{`Search results for "${query}"`}</CardTitle>
         </CardHeader>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,21 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./lib/**/*.{ts,tsx}",
+  ],
+  theme: {
+    container: {
+      center: true,
+      screens: {
+        "2xl": "1600px",
+      },
+    },
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add Tailwind config to customize container widths
- widen page containers from `max-w-2xl` to `max-w-3xl`

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ac524afd083299d7d0cd5f32951a4