### PR TITLE
Skip API call for empty markdown paragraphs

### DIFF
--- a/scripts/translate_markdown.py
+++ b/scripts/translate_markdown.py
@@ -19,6 +19,9 @@ SYSTEM_PROMPT = (
 )
 
 async def translate_paragraph(client: openai.AsyncOpenAI, text: str) -> str:
+    if not text.strip():
+        return text
+
     for attempt in range(MAX_RETRIES + 1):
         try:
             response = await client.chat.completions.create(


### PR DESCRIPTION
## Summary
- avoid calling OpenAI API in `translate_markdown.py` when paragraphs are empty

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684aedca71748329aa88b1f4ab170fb9