### PR TITLE
Add script to run marker on all papers

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "format": "prettier --write .",
-    "papers:translate": "scripts/translate_all_papers.sh"
+    "papers:translate": "scripts/translate_all_papers.sh",
+    "papers:marker": "scripts/run_marker_all_papers.sh"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",

--- a/scripts/run_marker_all_papers.sh
+++ b/scripts/run_marker_all_papers.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+for pdf in public/papers/*.pdf; do
+  [ -e "$pdf" ] || continue
+  scripts/run_marker.sh "$pdf"
+done


### PR DESCRIPTION
## Summary
- add `run_marker_all_papers.sh` helper
- expose script via `npm run papers:marker`

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684afde7310c8329be4a0b3ec895c508